### PR TITLE
Added  debug flag for better debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ By default, GH Local Changes scans the current directory. You can specify a diff
 gh local-changes ~/source
 ```
 
+To print debug logs , use --debug flag :
+
+```
+gh local-changes --debug
+gh local-changes --debug  ~/source
+```
+
 GH Local Changes will recursively scan the specified directory for Git repositories. For each repository, it will report the branches and changes that have not been pushed to the remote repository.
 
 ## Contributing

--- a/git.go
+++ b/git.go
@@ -32,7 +32,7 @@ var unpushedBranchesCommand = []string{"log", "--branches", "--not", "--remotes"
 func (r *GitRepo) getUnpushedBranches() (map[string]string, error) {
 	out, err := runGit(r.folder, unpushedBranchesCommand...)
 	if err != nil {
-		return nil, fmt.Errorf("error running git log: %w", err)
+		return nil, fmt.Errorf("Error running git log: %w", err)
 	}
 
 	branches := make(map[string]string)

--- a/main.go
+++ b/main.go
@@ -92,21 +92,25 @@ var debug bool
 func main() {
 	defer printLookingForContributors()
 	flag.BoolVar(&debug, "debug", false, "Enable debug logging")
-	flag.Parse()
-	args := flag.Args()
+
 	dir := "."
-	if len(args) > 0 {
-		dir = args[0]
-		if dir == "-h" || dir == "--help" {
+	for _, arg := range os.Args[1:] {
+		if arg == "-h" || arg == "--help" {
 			log.Info("Usage: go-gh [dir]")
 			os.Exit(0)
 		}
+	}
+	flag.Parse()
+	parsedArgs := flag.Args()
+
+	if len(parsedArgs) > 0 {
+		dir = parsedArgs[0]
 		// Fail if the directory does not exist
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
 			log.Fatal("Directory does not exist:", dir)
 		}
 	}
-	//set log level as debug
+
 	if debug {
 		log.SetLevel(log.DebugLevel)
 	}


### PR DESCRIPTION
## Description
The debug logs were never printed as by default log level was INFO
A user can get debug logs when passed boolean flag: --debug
Also improved the debug logs with the path as key and repoName as value

Fix #3

## Latest Screenshots (if applicable)

**Scenario 1**: _With --debug flag without source path_

<img width="1894" height="908" alt="image" src="https://github.com/user-attachments/assets/e8dbaefd-5d72-422c-a201-df050137d8e9" />

**Scenario 2**: _With --help flag without source path_

<img width="1066" height="110" alt="image" src="https://github.com/user-attachments/assets/7675c7db-fa25-4af6-ba51-76bbb1d3ca22" />

**Scenario 3**: _With --debug flag and source path_
_Ex: gh local-changes --debug "C:\Users\AnjaliD\Documents\CXRepo\astCli-main"_

<img width="1798" height="427" alt="image" src="https://github.com/user-attachments/assets/b4b6aacc-7d8e-40d7-9375-ba3a7d4e575e" />

**Scenario 4**:  _With help flag and source path_
_Ex: gh local-changes "C:\Users\AnjaliD\Documents\CXRepo\astCli-main" -h_

<img width="1620" height="111" alt="image" src="https://github.com/user-attachments/assets/d28f628f-d6d8-436b-9bcb-c8b54d85d79f" />

**Scenario 5**: _Without debug / help flag , info level logs are printed_ 
_Ex: gh local-changes_

<img width="1869" height="530" alt="image" src="https://github.com/user-attachments/assets/1a43fdf5-2a30-4ee6-bcdc-e897b0759776" />

Scenario 6: Without debug/help flag, and source path , info level logs are printed with changes
_Ex: gh local-changes "C:\Users\AnjaliD\Documents\CXRepo\astCli-main"_

<img width="1900" height="382" alt="image" src="https://github.com/user-attachments/assets/ee7ff6c1-7489-4dd2-9908-8e7b23588f2e" />


